### PR TITLE
ci: use yarn instead of npm

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
-          npm install
-          npm run build
+          yarn install
+          yarn run build
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>