### PR TITLE
feat: publish Electron App in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Build and Release Electron App
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Electron app for macOS
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: yarn dist --mac
+      - name: Upload macOS build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: electron-app-macos
+          path: dist/*.dmg
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Electron app for Windows
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: yarn dist --win
+      - name: Upload Windows build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: electron-app-windows
+          path: dist/*.exe
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Electron app for Linux
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: yarn dist --linux
+      - name: Upload Linux build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: electron-app-linux
+          path: dist/*.AppImage
+
+  release:
+    needs: [build-macos, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Download macOS build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: electron-app-macos
+          path: dist/macos
+      - name: Download Windows build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: electron-app-windows
+          path: dist/windows
+      - name: Download Linux build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: electron-app-linux
+          path: dist/linux
+      - name: Create GitHub Release and Upload Assets
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          artifacts: |
+            dist/macos/*.dmg
+            dist/windows/*.exe
+            dist/linux/*.AppImage
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Build and Release Electron App
 
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+on: [push, pull_request]
 
 jobs:
   build-macos:
@@ -14,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20.8.1'
       - name: Install dependencies
         run: yarn install
       - name: Build Electron app for macOS
@@ -35,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20.8.1'
       - name: Install dependencies
         run: yarn install
       - name: Build Electron app for Windows
@@ -56,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20.8.1'
       - name: Install dependencies
         run: yarn install
       - name: Build Electron app for Linux
@@ -75,6 +72,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.8.1'
+      - name: Clear npm cache
+        run: npm cache clean --force
       - name: Download macOS build artifacts
         uses: actions/download-artifact@v2
         with:
@@ -90,15 +93,7 @@ jobs:
         with:
           name: electron-app-linux
           path: dist/linux
-      - name: Create GitHub Release and Upload Assets
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ github.ref }}
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          artifacts: |
-            dist/macos/*.dmg
-            dist/windows/*.exe
-            dist/linux/*.AppImage
-          token: ${{ secrets.GH_TOKEN }}
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: yarn release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Build and Release Electron App
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-macos:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "npx serve@latest out",
     "lint": "next lint",
     "electron": "electron .",
-    "dist": "yarn build && electron-builder"
+    "dist": "yarn build && electron-builder",
+    "release": "npx -p semantic-release -p @semantic-release/git -p @semantic-release/changelog -p @semantic-release/exec semantic-release"
   },
   "build": {
     "appId": "org.casbin.editor",
@@ -45,6 +46,34 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
     }
+  },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/github",
+        {
+          "assets": [
+            {
+              "path": "dist/macos/*.dmg",
+              "label": "macOS"
+            },
+            {
+              "path": "dist/windows/*.exe",
+              "label": "Windows"
+            },
+            {
+              "path": "dist/linux/*.AppImage",
+              "label": "Linux"
+            }
+          ]
+        }
+      ]
+    ]
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
       "identity": null,
       "hardenedRuntime": false
     },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ],
+      "category": "Utility",
+      "maintainer": "org.casbin.editor"
+    },
     "win": {
       "target": "nsis"
     },


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-editor/issues/110

**Workflow Name**
Build and Release Electron App

**Trigger condition**
This workflow is triggered when a label conforming to the v*.*. Format is pushed. Specifically, when you push a tag that conforms to the vX.Y.Z format (e.g. v1.0.0, v2.1.3, etc.), this workflow is automatically executed.
```
git tag v1.0.0
git push origin v1.0.0
```
**Required GitHub Secrets**
GH_TOKEN: GitHub token, which requires sufficient permissions to clone repositories, install dependencies, publish releases, and upload artifacts.
1. Generate a GitHub Token

- Click on your profile picture, and then select Settings.
- On the left-hand menu, select Developer settings.
- Select Personal access tokens.
- Create a new Token
- Select the required permissions (all permissions related to the repo are required).

2.Add to the current project.

- Click on the "New repository secret" button.
- Enter the name "GH_TOKEN" in the Name field.
- Paste the GitHub Token you just copied in Value.

![7da409b112ce527ec0142a273e478380](https://github.com/casbin/casbin-editor/assets/92775570/d5a7bad4-5a31-436c-adac-e142bb14738d)
