### PR TITLE
fix: Fix the ButtonWidget image display issue in Electron build

### DIFF
--- a/app/components/editor/ButtonPlugin.ts
+++ b/app/components/editor/ButtonPlugin.ts
@@ -20,7 +20,7 @@ class ButtonWidget extends WidgetType {
     button.className = `flex items-center rounded text-[#453d7d] px-1 border border-[#453d7d] 
       bg-[#efefef] hover:bg-[#453d7d] hover:text-white transition-colors duration-500 
       font-medium whitespace-nowrap overflow-hidden`;
-    button.innerHTML = '<img src="/openai.svg" alt="" class="w-4 h-4 mr-1" /> Ask AI';
+    button.innerHTML = '<img src="openai.svg" alt="" class="w-4 h-4 mr-1" /> Ask AI';
     button.style.position = 'absolute';
     button.style.right = '1px';
     button.style.top = '1px';


### PR DESCRIPTION
Before.
<img width="1312" alt="image" src="https://github.com/casbin/casbin-editor/assets/92775570/6966b77e-fb29-4301-9ab7-5dfe29396c96">
Fixed.
<img width="1312" alt="image" src="https://github.com/casbin/casbin-editor/assets/92775570/616ac766-0ffa-4733-a952-318e07606355">
