### PR TITLE
fix: load shared content when it has a non default model kind

### DIFF
--- a/app/components/editor/hooks/useIndex.tsx
+++ b/app/components/editor/hooks/useIndex.tsx
@@ -1,4 +1,4 @@
-import React, { isValidElement, ReactNode, useEffect, useState } from 'react';
+import React, { isValidElement, ReactNode, useEffect, useRef, useState } from 'react';
 import { defaultCustomConfig, defaultEnforceContext, example, ModelKind } from '@/app/components/editor/casbin-mode/example';
 import { ShareFormat } from '@/app/components/editor/hooks/useShareInfo';
 import { defaultEnforceContextData } from '@/app/components/editor/hooks/useSetupEnforceContext';
@@ -13,6 +13,7 @@ export default function useIndex() {
   const [customConfig, setCustomConfig] = useState('');
   const [share, setShare] = useState('');
   const [enforceContextData, setEnforceContextData] = useState(new Map(defaultEnforceContextData));
+  const lastHash = useRef<string>();
 
   function setPolicyPersistent(text: string): void {
     setPolicy(text);
@@ -37,7 +38,8 @@ export default function useIndex() {
 
   useEffect(() => {
     const hash = window.location.hash.slice(1);
-    if (hash) {
+    if (hash && lastHash.current != hash) {
+      lastHash.current = hash;
       setEcho(<div>Loading Shared Content...</div>);
       fetch(`https://dpaste.com/${hash}.txt`)
         .then((resp) => {
@@ -62,8 +64,8 @@ export default function useIndex() {
           window.location.hash = ''; // prevent duplicate load
           setEcho(<div>Shared Content Loaded.</div>);
         })
-        .catch(() => {
-          setEcho(<div>Failed to load Shared Content.</div>);
+        .catch((error) => {
+          setEcho(<div>`Failed to load Shared Content.${error.message}`</div>);
         });
     }
   }, []);


### PR DESCRIPTION
When content has been shared and the modelKind is not the default (ACL) the order of state change effects means that the loaded shared content is overridden by the example for the shared modelKind.

This PR applies the modelKind from the shared content, persists the shared content as a Ref, then applies the shared content Ref in the modelKind state change effect before clearing the persisted shared content Ref so that the next model kind change will apply the example for the selected model kind.

This PR also applies the shared custom config.

I am new to React so this may not be the best fix, but it works and retains the standard model kind state change behaviour.