### PR TITLE
fix: ensure that shared content loads correctly under the basic model, fix bug introduced by PR: #169

### DIFF
--- a/app/components/editor/hooks/useIndex.tsx
+++ b/app/components/editor/hooks/useIndex.tsx
@@ -12,6 +12,7 @@ export default function useIndex() {
   const [requestResult, setRequestResult] = useState('');
   const [customConfig, setCustomConfig] = useState('');
   const [share, setShare] = useState('');
+  const [triggerUpdate, setTriggerUpdate] = useState(0);
   const [enforceContextData, setEnforceContextData] = useState(new Map(defaultEnforceContextData));
   const loadState = useRef<{
     loadedHash?: string;
@@ -54,6 +55,9 @@ export default function useIndex() {
           loadState.current.content = parsed;
           const newModelKind = parsed?.modelKind && parsed.modelKind in example ? (parsed.modelKind as ModelKind) : 'basic';
           setModelKind(newModelKind);
+          setTriggerUpdate((prev) => {
+            return prev + 1;
+          });
           setEcho(<div className="text-green-500">Shared Content Loaded.</div>);
         })
         .catch((error) => {
@@ -69,9 +73,9 @@ export default function useIndex() {
     setModelText(shared?.model ?? example[modelKind].model);
     setRequest(shared?.request ?? example[modelKind].request);
     setCustomConfig(shared?.customConfig ?? defaultCustomConfig);
-    setEnforceContextData(new Map(Object.entries(JSON.parse(example[modelKind].enforceContext || defaultEnforceContext))));
+    setEnforceContextData(new Map(Object.entries(JSON.parse(shared?.enforceContext || example[modelKind].enforceContext || defaultEnforceContext))));
     loadState.current.content = undefined;
-  }, [modelKind]);
+  }, [modelKind, triggerUpdate]);
 
   function handleShare(v: ReactNode | string) {
     if (isValidElement(v)) {

--- a/app/components/editor/hooks/useShareInfo.tsx
+++ b/app/components/editor/hooks/useShareInfo.tsx
@@ -25,6 +25,7 @@ export interface ShareFormat {
   customConfig?: string;
   request?: string;
   requestResult?: object;
+  enforceContext?: string;
 }
 
 async function dpaste(content: string) {


### PR DESCRIPTION
Fix bug introduced by PR: https://github.com/casbin/casbin-editor/pull/169

## Description:
When users modify content while using the `basic`(ACL) model and generate a share link, there is an issue where the content does not update when opening this link.
## Reason:
In the original code, `useEffect` only depends on `modelKind`. If the shared content uses the `basic` `modelKind`, it will not trigger an update of `useEffect`, resulting in the data for `enforceContext` being unable to be passed through the sharing link.
## Resolve:
Add a `triggerUpdate` state counter and include it in the `useEffect` dependencies to force content updates.
