### PR TITLE
feat: fix the bug that `matchingForGFunction` and `matchingDomainForGFunction` can affect the logic of role matching and domain matching

### DIFF
--- a/app/components/editor/casbin-mode/example.ts
+++ b/app/components/editor/casbin-mode/example.ts
@@ -437,12 +437,6 @@ export const defaultCustomConfig = `(function() {
   return arg1.endsWith(arg2);
 }
     },
-    matchingForGFunction: (user, role) => {
-  return user.department === role.department;
-},
-    matchingDomainForGFunction: (domain1, domain2) => {
-  return domain1.startsWith(domain2);
-}
   };
 })();`;
 export const defaultEnforceContext = `{


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-editor/issues/184

## Reason
- `matchingForGFunction` and `matchingDomainForGFunction` can affect the logic of role matching and domain matching, potentially leading to results that do not align with expectations.

## Resolve
- Remove the default loaded `matchingForGFunction` and `matchingDomainForGFunction.`

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/0bdf2ed1-a5ed-4a6b-9bc9-38db3bf078fa" />
