### PR TITLE
feat: show engine and CLI versions in engine dropdown widget

### DIFF
--- a/app/components/editor/CasbinEngine.ts
+++ b/app/components/editor/CasbinEngine.ts
@@ -18,18 +18,14 @@ export interface ICasbinEngine {
     enforceContextData?: Map<string, string>;
   }): Promise<EnforceResult>;
 
-  getVersion(): Promise<string>;
-  getType(): 'node' | 'java' | 'go';
+  getVersion?(): Promise<string>;
 }
 
 // Node.js
 export class NodeCasbinEngine implements ICasbinEngine {
   async enforce(params) {
     try {
-      const e = await newEnforcer(
-        newModel(params.model),
-        params.policy ? new StringAdapter(params.policy) : undefined
-      );
+      const e = await newEnforcer(newModel(params.model), params.policy ? new StringAdapter(params.policy) : undefined);
 
       setupRoleManager(e);
 
@@ -47,14 +43,6 @@ export class NodeCasbinEngine implements ICasbinEngine {
     } catch (error) {
       throw error;
     }
-  }
-
-  async getVersion(): Promise<string> {
-    return process.env.CASBIN_VERSION || 'unknown';
-  }
-
-  getType(): 'node' {
-    return 'node';
   }
 }
 
@@ -87,10 +75,6 @@ export class RemoteCasbinEngine implements ICasbinEngine {
 
   async getVersion(): Promise<string> {
     return getRemoteVersion(this.engine);
-  }
-
-  getType(): 'java' | 'go' {
-    return this.engine;
   }
 }
 

--- a/app/components/editor/CasbinEngine.ts
+++ b/app/components/editor/CasbinEngine.ts
@@ -1,7 +1,6 @@
 import { newEnforcer, newModel, StringAdapter } from 'casbin';
-import { remoteEnforcer } from './hooks/useRemoteEnforcer';
+import { remoteEnforcer, getRemoteVersion, VersionInfo } from './hooks/useRemoteEnforcer';
 import { setupRoleManager, setupCustomConfig, processRequests } from '@/app/utils/casbinEnforcer';
-import { getRemoteVersion } from './hooks/useRemoteEnforcer';
 
 interface EnforceResult {
   allowed: boolean;
@@ -18,7 +17,7 @@ export interface ICasbinEngine {
     enforceContextData?: Map<string, string>;
   }): Promise<EnforceResult>;
 
-  getVersion?(): Promise<string>;
+  getVersion?(): Promise<VersionInfo>;
 }
 
 // Node.js
@@ -73,7 +72,7 @@ export class RemoteCasbinEngine implements ICasbinEngine {
     }
   }
 
-  async getVersion(): Promise<string> {
+  async getVersion(): Promise<VersionInfo> {
     return getRemoteVersion(this.engine);
   }
 }

--- a/app/components/editor/CasbinEngine.ts
+++ b/app/components/editor/CasbinEngine.ts
@@ -1,6 +1,7 @@
 import { newEnforcer, newModel, StringAdapter } from 'casbin';
 import { remoteEnforcer } from './hooks/useRemoteEnforcer';
 import { setupRoleManager, setupCustomConfig, processRequests } from '@/app/utils/casbinEnforcer';
+import { getRemoteVersion } from './hooks/useRemoteEnforcer';
 
 interface EnforceResult {
   allowed: boolean;
@@ -17,7 +18,7 @@ export interface ICasbinEngine {
     enforceContextData?: Map<string, string>;
   }): Promise<EnforceResult>;
 
-  getVersion(): string;
+  getVersion(): Promise<string>;
   getType(): 'node' | 'java' | 'go';
 }
 
@@ -48,8 +49,8 @@ export class NodeCasbinEngine implements ICasbinEngine {
     }
   }
 
-  getVersion(): string {
-    return process.env.CASBIN_VERSION || '';
+  async getVersion(): Promise<string> {
+    return process.env.CASBIN_VERSION || 'unknown';
   }
 
   getType(): 'node' {
@@ -84,8 +85,8 @@ export class RemoteCasbinEngine implements ICasbinEngine {
     }
   }
 
-  getVersion(): string {
-    return '';
+  async getVersion(): Promise<string> {
+    return getRemoteVersion(this.engine);
   }
 
   getType(): 'java' | 'go' {

--- a/app/components/editor/hooks/useEngineVersions.ts
+++ b/app/components/editor/hooks/useEngineVersions.ts
@@ -1,82 +1,130 @@
 import { useState, useEffect } from 'react';
 import { createCasbinEngine } from '../CasbinEngine';
-import { VersionInfo } from '../hooks/useRemoteEnforcer';
 
-interface EngineVersions {
-  javaVersion: {
-    engine: string;
-    lib: string;
-  };
-  goVersion: {
-    engine: string;
-    lib: string;
-  };
-  casbinVersion: string | undefined;
-  engineGithubLinks: {
-    node: string;
-    java: string;
-    go: string;
-  };
+type EngineType = 'java' | 'go' | 'node';
+
+interface VersionInfo {
+  engine: string;
+  lib: string;
 }
 
-export default function useEngineVersions(isEngineLoading: boolean): EngineVersions {
-  const [javaVersion, setJavaVersion] = useState<{ engine: string; lib: string }>({ engine: '', lib: '' });
-  const [goVersion, setGoVersion] = useState<{ engine: string; lib: string }>({ engine: '', lib: '' });
+const ENGINE_CONFIGS: Record<
+  EngineType,
+  {
+    githubRepo: string;
+    createEngine: () => ReturnType<typeof createCasbinEngine>;
+  }
+> = {
+  java: {
+    githubRepo: 'casbin/jcasbin',
+    createEngine: () => {
+      return createCasbinEngine('java');
+    },
+  },
+  go: {
+    githubRepo: 'casbin/casbin',
+    createEngine: () => {
+      return createCasbinEngine('go');
+    },
+  },
+  node: {
+    githubRepo: 'casbin/node-casbin',
+    createEngine: () => {
+      return createCasbinEngine('node');
+    },
+  },
+};
+
+export default function useEngineVersions(isEngineLoading: boolean): EngineVersionsReturn {
+  const [versions, setVersions] = useState<Record<EngineType, VersionInfo>>(() => {
+    return Object.keys(ENGINE_CONFIGS).reduce(
+      (acc, key) => {
+        return {
+          ...acc,
+          [key]: { engine: '', lib: '' },
+        };
+      },
+      {} as Record<EngineType, VersionInfo>,
+    );
+  });
+
   const casbinVersion = process.env.CASBIN_VERSION;
 
   useEffect(() => {
     const getAllVersions = async () => {
-      if (!isEngineLoading) {
-        try {
-          const javaEngine = createCasbinEngine('java');
-          const goEngine = createCasbinEngine('go');
+      if (isEngineLoading) return;
 
-          const [jVersion, gVersion] = (await Promise.all([javaEngine.getVersion?.(), goEngine.getVersion?.()])) as [
-            VersionInfo | undefined,
-            VersionInfo | undefined,
-          ];
+      try {
+        const versionPromises = Object.entries(ENGINE_CONFIGS).map(async ([type, config]) => {
+          const engine = config.createEngine();
+          const version = await engine.getVersion?.();
+          return [type, version] as const;
+        });
 
-          if (jVersion) {
-            setJavaVersion({
-              engine: jVersion.engineVersion,
-              lib: jVersion.libVersion,
-            });
-          }
+        const results = await Promise.all(versionPromises);
 
-          if (gVersion) {
-            setGoVersion({
-              engine: gVersion.engineVersion,
-              lib: gVersion.libVersion,
-            });
-          }
-        } catch (error) {
-          console.error('Error getting versions:', error);
-          setJavaVersion({ engine: 'unknown', lib: 'unknown' });
-          setGoVersion({ engine: 'unknown', lib: 'unknown' });
-        }
+        const newVersions = results.reduce(
+          (acc, [type, version]) => {
+            return {
+              ...acc,
+              [type]: version ? { engine: version.engineVersion, lib: version.libVersion } : { engine: 'unknown', lib: 'unknown' },
+            };
+          },
+          {} as Record<EngineType, VersionInfo>,
+        );
+
+        setVersions(newVersions);
+      } catch (error) {
+        console.error('Error getting versions:', error);
+        const defaultVersions = Object.keys(ENGINE_CONFIGS).reduce(
+          (acc, key) => {
+            return {
+              ...acc,
+              [key]: { engine: 'unknown', lib: 'unknown' },
+            };
+          },
+          {} as Record<EngineType, VersionInfo>,
+        );
+
+        setVersions(defaultVersions);
       }
     };
+
     getAllVersions();
   }, [isEngineLoading]);
 
-  const getVersionedLink = (base: string, version: string | undefined | null) => {
+  const getVersionedLink = (base: string, version?: string | null) => {
     if (!version || version === 'unknown') {
       return base;
     }
+
     const versionNumber = version.startsWith('v') ? version.substring(1) : version;
     return `${base}tag/v${versionNumber}`;
   };
 
-  const engineGithubLinks = {
-    node: getVersionedLink('https://github.com/casbin/node-casbin/releases/', casbinVersion),
-    java: getVersionedLink('https://github.com/casbin/jcasbin/releases/', javaVersion.lib),
-    go: getVersionedLink('https://github.com/casbin/casbin/releases/', goVersion.lib),
-  };
+  const engineGithubLinks = Object.entries(ENGINE_CONFIGS).reduce(
+    (acc, [type, config]) => {
+      return {
+        ...acc,
+        [type]:
+          type === 'node'
+            ? getVersionedLink(`https://github.com/${config.githubRepo}/releases/`, casbinVersion)
+            : getVersionedLink(`https://github.com/${config.githubRepo}/releases/`, versions[type as EngineType]?.lib),
+      };
+    },
+    {} as Record<string, string>,
+  );
 
   return {
-    javaVersion,
-    goVersion,
+    javaVersion: versions.java,
+    goVersion: versions.go,
     casbinVersion,
     engineGithubLinks,
   };
+}
+export interface EngineVersionsReturn {
+  javaVersion: VersionInfo;
+  goVersion: VersionInfo;
+  casbinVersion: string | undefined;
+  engineGithubLinks: Record<string, string>;
 }

--- a/app/components/editor/hooks/useEngineVersions.ts
+++ b/app/components/editor/hooks/useEngineVersions.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import { createCasbinEngine } from '../CasbinEngine';
+
+interface EngineVersions {
+  javaVersion: string;
+  goVersion: string;
+  casbinVersion: string | undefined;
+  engineGithubLinks: {
+    node: string;
+    java: string;
+    go: string;
+  };
+}
+
+export default function useEngineVersions(isEngineLoading: boolean): EngineVersions {
+  const [javaVersion, setJavaVersion] = useState<string>('');
+  const [goVersion, setGoVersion] = useState<string>('');
+  const casbinVersion = process.env.CASBIN_VERSION;
+
+  useEffect(() => {
+    const getAllVersions = async () => {
+      if (!isEngineLoading) {
+        try {
+          const javaEngine = createCasbinEngine('java');
+          const goEngine = createCasbinEngine('go');
+
+          const [jVersion, gVersion] = await Promise.all([javaEngine.getVersion(), goEngine.getVersion()]);
+
+          setJavaVersion(jVersion);
+          setGoVersion(gVersion);
+        } catch (error) {
+          console.error('Error getting versions:', error);
+        }
+      }
+    };
+    getAllVersions();
+  }, [isEngineLoading]);
+
+  const engineGithubLinks = {
+    node: `https://github.com/casbin/node-casbin/releases/tag/v${casbinVersion || 'latest'}`,
+    java: `https://github.com/casbin/jcasbin/releases/tag/v${javaVersion || 'latest'}`,
+    go: `https://github.com/casbin/casbin/releases/tag/v${goVersion || 'latest'}`,
+  };
+
+  return {
+    javaVersion,
+    goVersion,
+    casbinVersion,
+    engineGithubLinks,
+  };
+}

--- a/app/components/editor/hooks/useEngineVersions.ts
+++ b/app/components/editor/hooks/useEngineVersions.ts
@@ -24,10 +24,7 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
           const javaEngine = createCasbinEngine('java');
           const goEngine = createCasbinEngine('go');
 
-          const [jVersion, gVersion] = await Promise.all([
-            javaEngine.getVersion(),
-            goEngine.getVersion()
-          ]);
+          const [jVersion, gVersion] = await Promise.all([javaEngine.getVersion?.(), goEngine.getVersion?.()]);
 
           setJavaVersion(jVersion || 'unknown');
           setGoVersion(gVersion || 'unknown');

--- a/app/components/editor/hooks/useEngineVersions.ts
+++ b/app/components/editor/hooks/useEngineVersions.ts
@@ -63,7 +63,8 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
     if (!version || version === 'unknown') {
       return base;
     }
-    return `${base}tag/v${version}`;
+    const versionNumber = version.startsWith('v') ? version.substring(1) : version;
+    return `${base}tag/v${versionNumber}`;
   };
 
   const engineGithubLinks = {

--- a/app/components/editor/hooks/useEngineVersions.ts
+++ b/app/components/editor/hooks/useEngineVersions.ts
@@ -24,22 +24,34 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
           const javaEngine = createCasbinEngine('java');
           const goEngine = createCasbinEngine('go');
 
-          const [jVersion, gVersion] = await Promise.all([javaEngine.getVersion(), goEngine.getVersion()]);
+          const [jVersion, gVersion] = await Promise.all([
+            javaEngine.getVersion(),
+            goEngine.getVersion()
+          ]);
 
-          setJavaVersion(jVersion);
-          setGoVersion(gVersion);
+          setJavaVersion(jVersion || 'unknown');
+          setGoVersion(gVersion || 'unknown');
         } catch (error) {
           console.error('Error getting versions:', error);
+          setJavaVersion('unknown');
+          setGoVersion('unknown');
         }
       }
     };
     getAllVersions();
   }, [isEngineLoading]);
 
+  const getVersionedLink = (base: string, version: string | undefined | null) => {
+    if (!version || version === 'unknown') {
+      return base;
+    }
+    return `${base}tag/v${version}`;
+  };
+
   const engineGithubLinks = {
-    node: `https://github.com/casbin/node-casbin/releases/tag/v${casbinVersion || 'latest'}`,
-    java: `https://github.com/casbin/jcasbin/releases/tag/v${javaVersion || 'latest'}`,
-    go: `https://github.com/casbin/casbin/releases/tag/v${goVersion || 'latest'}`,
+    node: getVersionedLink('https://github.com/casbin/node-casbin/releases/', casbinVersion),
+    java: getVersionedLink('https://github.com/casbin/jcasbin/releases/', javaVersion),
+    go: getVersionedLink('https://github.com/casbin/casbin/releases/', goVersion),
   };
 
   return {

--- a/app/components/editor/hooks/useRemoteEnforcer.ts
+++ b/app/components/editor/hooks/useRemoteEnforcer.ts
@@ -76,3 +76,29 @@ export async function remoteEnforcer(props: RemoteEnforcerProps) {
     };
   }
 }
+
+export async function getRemoteVersion(language: 'java' | 'go'): Promise<string> {
+  try {
+    const baseUrl = 'https://door.casdoor.com/api/run-casbin-command';
+    const args = ['-v'];
+
+    const url = new URL(baseUrl);
+    url.searchParams.set('language', language);
+    url.searchParams.set('args', JSON.stringify(args));
+
+    const response = await fetch(url.toString());
+    const result = await response.json();
+
+    const versionInfo = result.data as string;
+    if (language === 'java') {
+      const match = versionInfo.match(/jcasbin\s+([\d.]+)/);
+      return match ? match[1] : 'unknown';
+    } else {
+      const match = versionInfo.match(/casbin\s+v([\d.]+)/);
+      return match ? match[1] : 'unknown';
+    }
+  } catch (error) {
+    console.error('Error getting remote version:', error);
+    return 'unknown';
+  }
+}

--- a/app/components/editor/hooks/useRemoteEnforcer.ts
+++ b/app/components/editor/hooks/useRemoteEnforcer.ts
@@ -97,7 +97,7 @@ export async function getRemoteVersion(language: 'java' | 'go'): Promise<Version
 
     const getVersionNumber = (line: string) => {
       const match = line.match(/(?:v|[\s])([\d.]+)/);
-      return match ? match[1] : 'unknown';
+      return match ? `v${match[1]}` : 'unknown';
     };
 
     return {

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -76,8 +76,8 @@ export const EditorScreen = () => {
   const casbinVersion = process.env.CASBIN_VERSION;
   const engineGithubLinks = {
     node: `https://github.com/casbin/node-casbin/releases/tag/v${casbinVersion}`,
-    java: 'https://github.com/casbin/jcasbin/releases',
-    go: 'https://github.com/casbin/casbin/releases',
+    java: `https://github.com/casbin/jcasbin/releases/tag/v${javaVersion}`,
+    go: `https://github.com/casbin/casbin/releases/tag/v${goVersion}`,
   };
 
   useEffect(() => {

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -25,7 +25,7 @@ import { casbinLinter } from '@/app/utils/casbinLinter';
 import { toast, Toaster } from 'react-hot-toast';
 import { CustomConfigPanel } from './CustomConfigPanel';
 import { loadingOverlay } from './LoadingOverlayExtension';
-import { createCasbinEngine } from './CasbinEngine';
+import useEngineVersions from './hooks/useEngineVersions';
 
 export const EditorScreen = () => {
   const {
@@ -71,57 +71,7 @@ export const EditorScreen = () => {
   const [isContentLoaded, setIsContentLoaded] = useState(false);
   const [isEngineLoading, setIsEngineLoading] = useState(false);
   const skipNextEffectRef = useRef(false);
-  const [javaVersion, setJavaVersion] = useState<string>('');
-  const [goVersion, setGoVersion] = useState<string>('');
-  const casbinVersion = process.env.CASBIN_VERSION;
-  const engineGithubLinks = {
-    node: `https://github.com/casbin/node-casbin/releases/tag/v${casbinVersion}`,
-    java: `https://github.com/casbin/jcasbin/releases/tag/v${javaVersion}`,
-    go: `https://github.com/casbin/casbin/releases/tag/v${goVersion}`,
-  };
-
-  useEffect(() => {
-    const getVersion = async () => {
-      if (!isEngineLoading && (selectedEngine === 'java' || selectedEngine === 'go')) {
-        try {
-          const engine = createCasbinEngine(selectedEngine);
-          const version = await engine.getVersion();
-          if (selectedEngine === 'java') {
-            setJavaVersion(version);
-          } else {
-            setGoVersion(version);
-          }
-        } catch (error) {
-          console.error('Error getting engine version:', error);
-          if (selectedEngine === 'java') {
-            setJavaVersion('unknown');
-          } else {
-            setGoVersion('unknown');
-          }
-        }
-      }
-    };
-    getVersion();
-  }, [selectedEngine, isEngineLoading]);
-
-  useEffect(() => {
-    const getAllVersions = async () => {
-      if (!isEngineLoading) {
-        try {
-          const javaEngine = createCasbinEngine('java');
-          const goEngine = createCasbinEngine('go');
-
-          const [jVersion, gVersion] = await Promise.all([javaEngine.getVersion(), goEngine.getVersion()]);
-
-          setJavaVersion(jVersion);
-          setGoVersion(gVersion);
-        } catch (error) {
-          console.error('Error getting versions:', error);
-        }
-      }
-    };
-    getAllVersions();
-  }, [isEngineLoading]);
+  const { javaVersion, goVersion, casbinVersion, engineGithubLinks } = useEngineVersions(isEngineLoading);
 
   useEffect(() => {
     if (modelKind && modelText) {

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -301,9 +301,13 @@ export const EditorScreen = () => {
                     });
                   }}
                 >
-                  <option value="node">Node-Casbin(NodeJs) v{casbinVersion}</option>
-                  <option value="java">jCasbin(Java) v{javaVersion}</option>
-                  <option value="go">Casbin(Go) v{goVersion}</option>
+                  <option value="node">Node-Casbin (NodeJs) v{casbinVersion}</option>
+                  <option value="java">
+                    jCasbin (Java) v{javaVersion.lib} (CLI v{javaVersion.engine})
+                  </option>
+                  <option value="go">
+                    Casbin (Go) v{goVersion.lib} (CLI v{goVersion.engine})
+                  </option>
                 </select>
                 <a href={engineGithubLinks[selectedEngine]} target="_blank" rel="noopener noreferrer" className="text-[#e13c3c] hover:text-[#ff4d4d]">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -25,6 +25,7 @@ import { casbinLinter } from '@/app/utils/casbinLinter';
 import { toast, Toaster } from 'react-hot-toast';
 import { CustomConfigPanel } from './CustomConfigPanel';
 import { loadingOverlay } from './LoadingOverlayExtension';
+import { createCasbinEngine } from './CasbinEngine';
 
 export const EditorScreen = () => {
   const {
@@ -70,12 +71,57 @@ export const EditorScreen = () => {
   const [isContentLoaded, setIsContentLoaded] = useState(false);
   const [isEngineLoading, setIsEngineLoading] = useState(false);
   const skipNextEffectRef = useRef(false);
+  const [javaVersion, setJavaVersion] = useState<string>('');
+  const [goVersion, setGoVersion] = useState<string>('');
   const casbinVersion = process.env.CASBIN_VERSION;
   const engineGithubLinks = {
     node: `https://github.com/casbin/node-casbin/releases/tag/v${casbinVersion}`,
     java: 'https://github.com/casbin/jcasbin/releases',
     go: 'https://github.com/casbin/casbin/releases',
   };
+
+  useEffect(() => {
+    const getVersion = async () => {
+      if (!isEngineLoading && (selectedEngine === 'java' || selectedEngine === 'go')) {
+        try {
+          const engine = createCasbinEngine(selectedEngine);
+          const version = await engine.getVersion();
+          if (selectedEngine === 'java') {
+            setJavaVersion(version);
+          } else {
+            setGoVersion(version);
+          }
+        } catch (error) {
+          console.error('Error getting engine version:', error);
+          if (selectedEngine === 'java') {
+            setJavaVersion('unknown');
+          } else {
+            setGoVersion('unknown');
+          }
+        }
+      }
+    };
+    getVersion();
+  }, [selectedEngine, isEngineLoading]);
+
+  useEffect(() => {
+    const getAllVersions = async () => {
+      if (!isEngineLoading) {
+        try {
+          const javaEngine = createCasbinEngine('java');
+          const goEngine = createCasbinEngine('go');
+
+          const [jVersion, gVersion] = await Promise.all([javaEngine.getVersion(), goEngine.getVersion()]);
+
+          setJavaVersion(jVersion);
+          setGoVersion(gVersion);
+        } catch (error) {
+          console.error('Error getting versions:', error);
+        }
+      }
+    };
+    getAllVersions();
+  }, [isEngineLoading]);
 
   useEffect(() => {
     if (modelKind && modelText) {
@@ -306,8 +352,8 @@ export const EditorScreen = () => {
                   }}
                 >
                   <option value="node">Node-Casbin(NodeJs) v{casbinVersion}</option>
-                  <option value="java">jCasbin(Java)</option>
-                  <option value="go">Casbin(Go)</option>
+                  <option value="java">jCasbin(Java) v{javaVersion}</option>
+                  <option value="go">Casbin(Go) v{goVersion}</option>
                 </select>
                 <a href={engineGithubLinks[selectedEngine]} target="_blank" rel="noopener noreferrer" className="text-[#e13c3c] hover:text-[#ff4d4d]">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -303,10 +303,10 @@ export const EditorScreen = () => {
                 >
                   <option value="node">Node-Casbin (NodeJs) {casbinVersion}</option>
                   <option value="java">
-                    jCasbin (Java) {javaVersion.libVersion} (CLI {javaVersion.engineVersion})
+                    jCasbin (Java) {javaVersion.libVersion} | (CLI {javaVersion.engineVersion})
                   </option>
                   <option value="go">
-                    Casbin (Go) {goVersion.libVersion} (CLI {goVersion.engineVersion})
+                    Casbin (Go) {goVersion.libVersion} | (CLI {goVersion.engineVersion})
                   </option>
                 </select>
                 <a href={engineGithubLinks[selectedEngine]} target="_blank" rel="noopener noreferrer" className="text-[#e13c3c] hover:text-[#ff4d4d]">

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -303,10 +303,10 @@ export const EditorScreen = () => {
                 >
                   <option value="node">Node-Casbin (NodeJs) {casbinVersion}</option>
                   <option value="java">
-                    jCasbin (Java) {javaVersion.lib} (CLI {javaVersion.engine})
+                    jCasbin (Java) {javaVersion.libVersion} (CLI {javaVersion.engineVersion})
                   </option>
                   <option value="go">
-                    Casbin (Go) {goVersion.lib} (CLI {goVersion.engine})
+                    Casbin (Go) {goVersion.libVersion} (CLI {goVersion.engineVersion})
                   </option>
                 </select>
                 <a href={engineGithubLinks[selectedEngine]} target="_blank" rel="noopener noreferrer" className="text-[#e13c3c] hover:text-[#ff4d4d]">

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -301,12 +301,12 @@ export const EditorScreen = () => {
                     });
                   }}
                 >
-                  <option value="node">Node-Casbin (NodeJs) v{casbinVersion}</option>
+                  <option value="node">Node-Casbin (NodeJs) {casbinVersion}</option>
                   <option value="java">
-                    jCasbin (Java) v{javaVersion.lib} (CLI v{javaVersion.engine})
+                    jCasbin (Java) {javaVersion.lib} (CLI {javaVersion.engine})
                   </option>
                   <option value="go">
-                    Casbin (Go) v{goVersion.lib} (CLI v{goVersion.engine})
+                    Casbin (Go) {goVersion.lib} (CLI {goVersion.engine})
                   </option>
                 </select>
                 <a href={engineGithubLinks[selectedEngine]} target="_blank" rel="noopener noreferrer" className="text-[#e13c3c] hover:text-[#ff4d4d]">


### PR DESCRIPTION
fix: https://github.com/casbin/casbin-editor/issues/200