### PR TITLE
fix: use standard JSON format for ABAC request examples

### DIFF
--- a/app/components/editor/casbin-mode/example.ts
+++ b/app/components/editor/casbin-mode/example.ts
@@ -308,8 +308,8 @@ e = some(where (p.eft == allow))
 [matchers]
 m = r.sub == r.obj.Owner`,
     policy: '',
-    request: `alice, { Owner: 'alice'}
-alice, { Owner: 'bob'}`,
+    request: `alice, { "Owner" : "alice" }
+alice, { "Owner" : "bob" }`,
     customConfig: undefined,
     enforceContext: undefined,
   },


### PR DESCRIPTION
fix:https://github.com/casbin/casbin-editor/issues/201

### Reason
The request example of the ABAC model uses JavaScript object literal format (using single quotes or no quotes), which causes the Go backend to be unable to correctly parse the request parameters, resulting in incorrect execution results.

### Resolve
- Change the request format in the ABAC example from a JavaScript object literal to standard JSON format.