### PR TITLE
fix: improve custom function panel layout flexibility

### DIFF
--- a/app/components/editor/CustomConfigPanel.tsx
+++ b/app/components/editor/CustomConfigPanel.tsx
@@ -242,10 +242,10 @@ export const CustomConfigPanel: React.FC<CustomConfigPanelProps> = ({
             <div className={textClass}>{t('Custom Functions')}</div>
           </div>
 
-          <div className="flex-grow overflow-auto " style={{ height: '100vh' }}>
+          <div className="flex-1 overflow-auto min-h-0">
             {functions.map((func) => {
               return (
-                <div key={func.id} className="bg-gray-100 rounded-lg flex flex-col" style={{ maxHeight: '50%' }}>
+                <div key={func.id} className="bg-gray-100 rounded-lg flex flex-col">
                   <div className="flex justify-between items-center p-2">
                     <input
                       type="text"


### PR DESCRIPTION
## Reason
The original layout utilized a fixed height of `height: 100vh` and `maxHeight: 50%`, which results in a less flexible layout on mobile devices.

Before:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/050f7ba9-bd2d-4b26-8abb-ad0690357527" />

After:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/a7c039a2-2ffb-4430-a3be-bf32f9d8f528" />
