### PR TITLE
refactor: centralize engine configuration and type definitions

### DIFF
--- a/app/components/editor/common/EngineSelector.tsx
+++ b/app/components/editor/common/EngineSelector.tsx
@@ -16,11 +16,13 @@ export const EngineSelector: React.FC<EngineSelectorProps> = ({ selectedEngine, 
   const { t } = useLang();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const engines = Object.entries(ENGINES).map(([id, config]) => ({
-    id,
-    name: config.name,
-    version: id === 'node' ? process.env.CASBIN_VERSION : versions[id as EngineType],
-  }));
+  const engines = Object.entries(ENGINES).map(([id, config]) => {
+    return {
+      id,
+      name: config.name,
+      version: id === 'node' ? process.env.CASBIN_VERSION : versions[id as EngineType],
+    };
+  });
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/app/components/editor/core/CasbinEngine.ts
+++ b/app/components/editor/core/CasbinEngine.ts
@@ -1,6 +1,7 @@
 import { newEnforcer, newModel, StringAdapter } from 'casbin';
 import { remoteEnforcer, getRemoteVersion, VersionInfo } from '@/app/components/hooks/useRemoteEnforcer';
 import { setupRoleManager, setupCustomConfig, processRequests } from '@/app/utils/casbinEnforcer';
+import type { EngineType } from '@/app/config/engineConfig';
 
 interface EnforceResult {
   allowed: boolean;
@@ -47,7 +48,7 @@ export class NodeCasbinEngine implements ICasbinEngine {
 
 // RemoteCasbinEngine
 export class RemoteCasbinEngine implements ICasbinEngine {
-  constructor(private engine: 'java' | 'go' | 'rust') {}
+  constructor(private engine: Exclude<EngineType, 'node'>) {}
 
   async enforce(params) {
     try {
@@ -77,15 +78,9 @@ export class RemoteCasbinEngine implements ICasbinEngine {
   }
 }
 
-export function createCasbinEngine(type: 'node' | 'java' | 'go' | 'rust'): ICasbinEngine {
-  switch (type) {
-    case 'node':
-      return new NodeCasbinEngine();
-    case 'java':
-    case 'go':
-    case 'rust':
-      return new RemoteCasbinEngine(type);
-    default:
-      throw new Error(`Unsupported engine type: ${type}`);
+export function createCasbinEngine(type: EngineType): ICasbinEngine {
+  if (type === 'node') {
+    return new NodeCasbinEngine();
   }
+  return new RemoteCasbinEngine(type);
 }

--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -31,6 +31,7 @@ import { formatEngineResults, ResultsMap } from '@/app/utils/resultFormatter';
 import { casbinLinter, policyLinter, requestLinter } from '@/app/utils/casbinLinter';
 import { useLang } from '@/app/context/LangContext';
 import LanguageMenu from '@/app/context/LanguageMenu';
+import type { EngineType } from '@/app/config/engineConfig';
 
 export const EditorScreen = () => {
   const {
@@ -70,7 +71,7 @@ export const EditorScreen = () => {
     onChange: setEnforceContextDataPersistent,
     data: enforceContextData,
   });
-  const { javaVersion, goVersion, casbinVersion, rustVersion, engineGithubLinks } = useEngineVersions(isLoading);
+  const { versions, engineGithubLinks } = useEngineVersions(isLoading);
   const { handleEnforcerCall } = useEnforceCall(enforcer, setEcho, setRequestResult, setRequestResults, setIsLoading, t);
   const openDrawerWithMessage = (message: string) => {
     if (sidePanelChatRef.current) {
@@ -130,7 +131,7 @@ export const EditorScreen = () => {
     setRequestResult,
   ]);
 
-  const handleEngineChange = (newPrimary: string, newComparison: string[]) => {
+  const handleEngineChange = (newPrimary: EngineType, newComparison: EngineType[]) => {
     skipNextEffectRef.current = true;
     setSelectedEngine(newPrimary);
     setComparisonEngines(newComparison);
@@ -279,10 +280,7 @@ export const EditorScreen = () => {
                 selectedEngine={selectedEngine}
                 comparisonEngines={comparisonEngines}
                 handleEngineChange={handleEngineChange}
-                casbinVersion={casbinVersion}
-                javaVersion={javaVersion}
-                goVersion={goVersion}
-                rustVersion={rustVersion}
+                versions={versions}
                 engineGithubLinks={engineGithubLinks}
               />
             </div>

--- a/app/components/editor/panels/PolicyToolbar.tsx
+++ b/app/components/editor/panels/PolicyToolbar.tsx
@@ -1,26 +1,16 @@
 import { FileUploadButton } from '@/app/components/editor/common/FileUploadButton';
 import { EngineSelector } from '@/app/components/editor/common/EngineSelector';
 import { EndpointSelector } from '@/app/components/editor/common/EndpointSelector';
+import type { EngineType } from '@/app/config/engineConfig';
+import type { VersionInfo } from '@/app/components/hooks/useRemoteEnforcer';
 
 interface PolicyToolbarProps {
   setPolicyPersistent: (content: string) => void;
-  selectedEngine: string;
-  comparisonEngines: string[];
-  handleEngineChange: (newPrimary: string, newComparison: string[]) => void;
-  casbinVersion?: string;
-  javaVersion?: {
-    libVersion: string;
-    engineVersion: string;
-  };
-  goVersion?: {
-    libVersion: string;
-    engineVersion: string;
-  };
-  rustVersion?: {
-    libVersion: string;
-    engineVersion: string;
-  };
-  engineGithubLinks: Record<string, string>;
+  selectedEngine: EngineType;
+  comparisonEngines: EngineType[];
+  handleEngineChange: (newPrimary: EngineType, newComparison: EngineType[]) => void;
+  versions: Record<EngineType, VersionInfo>;
+  engineGithubLinks: Record<EngineType, string>;
 }
 
 export const PolicyToolbar: React.FC<PolicyToolbarProps> = ({
@@ -28,10 +18,7 @@ export const PolicyToolbar: React.FC<PolicyToolbarProps> = ({
   selectedEngine,
   comparisonEngines,
   handleEngineChange,
-  casbinVersion,
-  javaVersion,
-  goVersion,
-  rustVersion,
+  versions,
   engineGithubLinks,
 }) => {
   return (
@@ -44,10 +31,7 @@ export const PolicyToolbar: React.FC<PolicyToolbarProps> = ({
         selectedEngine={selectedEngine}
         comparisonEngines={comparisonEngines}
         onEngineChange={handleEngineChange}
-        casbinVersion={casbinVersion}
-        javaVersion={javaVersion}
-        goVersion={goVersion}
-        rustVersion={rustVersion}
+        versions={versions}
         engineGithubLinks={engineGithubLinks}
       />
     </div>

--- a/app/components/hooks/useEngineVersions.ts
+++ b/app/components/hooks/useEngineVersions.ts
@@ -1,56 +1,16 @@
 import { useState, useEffect } from 'react';
-import { createCasbinEngine } from '@/app/components/editor/core/CasbinEngine';
-import { VersionInfo } from '@/app/components/hooks/useRemoteEnforcer';
-
-type EngineType = 'java' | 'go' | 'node' | 'rust';
+import { ENGINES, type EngineType } from '@/app/config/engineConfig';
+import type { VersionInfo } from '@/app/components/hooks/useRemoteEnforcer';
 
 export interface EngineVersionsReturn {
-  javaVersion: VersionInfo;
-  goVersion: VersionInfo;
-  rustVersion: VersionInfo;
+  versions: Record<EngineType, VersionInfo>;
   casbinVersion: string | undefined;
   engineGithubLinks: Record<EngineType, string>;
 }
 
-interface EngineConfig {
-  githubRepo: string;
-  createEngine: () => ReturnType<typeof createCasbinEngine>;
-}
-
-const ENGINE_CONFIGS: Record<EngineType, EngineConfig> = {
-  java: {
-    githubRepo: 'casbin/jcasbin',
-    createEngine: () => {
-      return createCasbinEngine('java');
-    },
-  },
-  go: {
-    githubRepo: 'casbin/casbin',
-    createEngine: () => {
-      return createCasbinEngine('go');
-    },
-  },
-  node: {
-    githubRepo: 'casbin/node-casbin',
-    createEngine: () => {
-      return createCasbinEngine('node');
-    },
-  },
-  rust: {
-    githubRepo: 'casbin/casbin-rs',
-    createEngine: () => {
-      return createCasbinEngine('rust');
-    },
-  },
-};
-
 export default function useEngineVersions(isEngineLoading: boolean): EngineVersionsReturn {
   const [versions, setVersions] = useState<Record<EngineType, VersionInfo>>(() => {
-    return Object.fromEntries(
-      Object.keys(ENGINE_CONFIGS).map((key) => {
-        return [key, { engineVersion: '', libVersion: '' }];
-      }),
-    ) as Record<EngineType, VersionInfo>;
+    return Object.fromEntries(Object.keys(ENGINES).map((key) => [key, { engineVersion: '', libVersion: '' }])) as Record<EngineType, VersionInfo>;
   });
 
   const casbinVersion = process.env.CASBIN_VERSION;
@@ -61,7 +21,7 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
 
       try {
         const versionEntries = await Promise.all(
-          Object.entries(ENGINE_CONFIGS).map(async ([type, config]) => {
+          Object.entries(ENGINES).map(async ([type, config]) => {
             const engine = config.createEngine();
             const version = await engine.getVersion?.();
             return [type, version || { engineVersion: 'unknown', libVersion: 'unknown' }] as const;
@@ -71,7 +31,7 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
         setVersions(Object.fromEntries(versionEntries) as Record<EngineType, VersionInfo>);
       } catch (error) {
         const defaultVersions = Object.fromEntries(
-          Object.keys(ENGINE_CONFIGS).map((key) => {
+          Object.keys(ENGINES).map((key) => {
             return [key, { engineVersion: 'unknown', libVersion: 'unknown' }];
           }),
         );
@@ -89,15 +49,13 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
   };
 
   const engineGithubLinks = Object.fromEntries(
-    Object.entries(ENGINE_CONFIGS).map(([type, config]) => {
+    Object.entries(ENGINES).map(([type, config]) => {
       return [type, getVersionedLink(config.githubRepo, type === 'node' ? casbinVersion : versions[type as EngineType]?.libVersion)];
     }),
   ) as Record<EngineType, string>;
 
   return {
-    javaVersion: versions.java,
-    goVersion: versions.go,
-    rustVersion: versions.rust,
+    versions,
     casbinVersion,
     engineGithubLinks,
   };

--- a/app/components/hooks/useEngineVersions.ts
+++ b/app/components/hooks/useEngineVersions.ts
@@ -10,7 +10,11 @@ export interface EngineVersionsReturn {
 
 export default function useEngineVersions(isEngineLoading: boolean): EngineVersionsReturn {
   const [versions, setVersions] = useState<Record<EngineType, VersionInfo>>(() => {
-    return Object.fromEntries(Object.keys(ENGINES).map((key) => [key, { engineVersion: '', libVersion: '' }])) as Record<EngineType, VersionInfo>;
+    return Object.fromEntries(
+      Object.keys(ENGINES).map((key) => {
+        return [key, { engineVersion: '', libVersion: '' }];
+      }),
+    ) as Record<EngineType, VersionInfo>;
   });
 
   const casbinVersion = process.env.CASBIN_VERSION;

--- a/app/components/hooks/useIndex.tsx
+++ b/app/components/hooks/useIndex.tsx
@@ -2,6 +2,7 @@ import React, { isValidElement, ReactNode, useEffect, useRef, useState } from 'r
 import { defaultCustomConfig, defaultEnforceContext, example } from '@/app/components/editor/casbin-mode/example';
 import { ShareFormat } from '@/app/components/hooks/useShareInfo';
 import { defaultEnforceContextData } from '@/app/components/hooks/useSetupEnforceContext';
+import type { EngineType } from '@/app/config/engineConfig';
 
 export default function useIndex() {
   const [modelKind, setModelKind] = useState('basic');
@@ -13,11 +14,16 @@ export default function useIndex() {
   const [customConfig, setCustomConfig] = useState('');
   const [share, setShare] = useState('');
   const [enforceContextData, setEnforceContextData] = useState(new Map(defaultEnforceContextData));
-  const [selectedEngine, setSelectedEngine] = useState('node');
-  const [comparisonEngines, setComparisonEngines] = useState<string[]>([]);
+  const [selectedEngine, setSelectedEngineState] = useState<EngineType>('node');
+  const [comparisonEngines, setComparisonEngines] = useState<EngineType[]>([]);
   const loadState = useRef<{
     loadedHash?: string;
   }>({});
+
+  const setSelectedEngine = (engine: EngineType) => {
+    setSelectedEngineState(engine);
+    localStorage.setItem('selectedEngine', engine);
+  };
 
   function setPolicyPersistent(text: string): void {
     setPolicy(text);
@@ -53,10 +59,10 @@ export default function useIndex() {
     );
 
     if (shared?.selectedEngine) {
-      setSelectedEngine(shared.selectedEngine);
+      setSelectedEngine(shared.selectedEngine as EngineType);
     }
     if (shared?.comparisonEngines) {
-      setComparisonEngines(shared.comparisonEngines);
+      setComparisonEngines(shared.comparisonEngines as EngineType[]);
     }
   };
 

--- a/app/components/hooks/useRunTest.tsx
+++ b/app/components/hooks/useRunTest.tsx
@@ -14,6 +14,7 @@
 
 import { createCasbinEngine } from '@/app/components/editor/core/CasbinEngine';
 import { setError, parseError } from '@/app/utils/errorManager';
+import type { EngineType } from '@/app/config/engineConfig';
 
 interface RunTestProps {
   model: string;
@@ -22,7 +23,7 @@ interface RunTestProps {
   customConfig: string;
   request: string;
   enforceContextData: Map<string, string>;
-  selectedEngine: string;
+  selectedEngine: EngineType;
   onResponse: (com: JSX.Element | any[]) => void;
 }
 
@@ -30,7 +31,7 @@ async function enforcer(props: RunTestProps) {
   const startTime = performance.now();
 
   try {
-    const engine = createCasbinEngine(props.selectedEngine as 'node' | 'java' | 'go');
+    const engine = createCasbinEngine(props.selectedEngine);
 
     const requests = props.request.split('\n').filter((line) => {
       return line.trim();

--- a/app/config/engineConfig.ts
+++ b/app/config/engineConfig.ts
@@ -17,7 +17,9 @@ export const ENGINES = {
     githubRepo: 'casbin/node-casbin',
     isRemote: false,
     order: 1,
-    createEngine: () => createCasbinEngine('node'),
+    createEngine: () => {
+      return createCasbinEngine('node');
+    },
   },
   java: {
     id: 'java',
@@ -25,7 +27,9 @@ export const ENGINES = {
     githubRepo: 'casbin/jcasbin',
     isRemote: true,
     order: 2,
-    createEngine: () => new RemoteCasbinEngine('java'),
+    createEngine: () => {
+      return new RemoteCasbinEngine('java');
+    },
   },
   go: {
     id: 'go',
@@ -33,7 +37,9 @@ export const ENGINES = {
     githubRepo: 'casbin/casbin',
     isRemote: true,
     order: 3,
-    createEngine: () => new RemoteCasbinEngine('go'),
+    createEngine: () => {
+      return new RemoteCasbinEngine('go');
+    },
   },
   rust: {
     id: 'rust',
@@ -41,7 +47,9 @@ export const ENGINES = {
     githubRepo: 'casbin/casbin-rs',
     isRemote: true,
     order: 4,
-    createEngine: () => new RemoteCasbinEngine('rust'),
+    createEngine: () => {
+      return new RemoteCasbinEngine('rust');
+    },
   },
 } as const;
 

--- a/app/config/engineConfig.ts
+++ b/app/config/engineConfig.ts
@@ -1,0 +1,58 @@
+import { NodeCasbinEngine, RemoteCasbinEngine, createCasbinEngine } from '@/app/components/editor/core/CasbinEngine';
+import type { ICasbinEngine } from '@/app/components/editor/core/CasbinEngine';
+
+export interface EngineConfig {
+  id: string;
+  name: string;
+  githubRepo: string;
+  isRemote: boolean;
+  order: number;
+  createEngine: () => ICasbinEngine;
+}
+
+export const ENGINES = {
+  node: {
+    id: 'node',
+    name: 'Node-Casbin (NodeJs)',
+    githubRepo: 'casbin/node-casbin',
+    isRemote: false,
+    order: 1,
+    createEngine: () => createCasbinEngine('node'),
+  },
+  java: {
+    id: 'java',
+    name: 'jCasbin (Java)',
+    githubRepo: 'casbin/jcasbin',
+    isRemote: true,
+    order: 2,
+    createEngine: () => new RemoteCasbinEngine('java'),
+  },
+  go: {
+    id: 'go',
+    name: 'Casbin (Go)',
+    githubRepo: 'casbin/casbin',
+    isRemote: true,
+    order: 3,
+    createEngine: () => new RemoteCasbinEngine('go'),
+  },
+  rust: {
+    id: 'rust',
+    name: 'Casbin-rs (Rust)',
+    githubRepo: 'casbin/casbin-rs',
+    isRemote: true,
+    order: 4,
+    createEngine: () => new RemoteCasbinEngine('rust'),
+  },
+} as const;
+
+export type EngineType = keyof typeof ENGINES;
+
+export function createEngine(type: EngineType) {
+  const config = ENGINES[type];
+  if (!config) throw new Error(`Unsupported engine type: ${type}`);
+
+  if (!config.isRemote) {
+    return new NodeCasbinEngine();
+  }
+  return new RemoteCasbinEngine(type as Exclude<EngineType, 'node'>);
+}

--- a/app/utils/resultFormatter.ts
+++ b/app/utils/resultFormatter.ts
@@ -1,42 +1,46 @@
-export interface EngineResult {
+import { EngineType, ENGINES } from '@/app/config/engineConfig';
+
+interface EngineResultData {
   result: string;
+  reason?: string[];
 }
 
 export interface ResultsMap {
-  [key: string]: EngineResult;
+  [key: string]: EngineResultData;
 }
 
-const ENGINE_ORDER = ['node', 'java', 'go', 'rust'];
-
-export function formatEngineResults(results: ResultsMap, selectedEngine: string): string {
+export function formatEngineResults(results: ResultsMap, selectedEngine: EngineType): string {
   const entries = Object.entries(results);
   if (entries.length === 1) return entries[0][1].result;
 
   return entries
-    .sort((a, b) => 
-      {return a[0] === selectedEngine ? -1 : 
-      b[0] === selectedEngine ? 1 : 
-      ENGINE_ORDER.indexOf(a[0]) - ENGINE_ORDER.indexOf(b[0])}
-    )
-    .map(([engine, { result }]) => {
-      const isPrimary = engine === selectedEngine;
-      return `// ${isPrimary ? '🟢' : '⚪️'} ${engine} Engine Result
-${result}
-// ${isPrimary ? '========================' : '----------------------------------------'}`;
+    .sort((a, b) => {
+      if (a[0] === selectedEngine) return -1;
+      if (b[0] === selectedEngine) return 1;
+      return ENGINES[a[0] as EngineType].order - ENGINES[b[0] as EngineType].order;
     })
+    .map(([engine, data]) => formatSingleResult(engine, data, engine === selectedEngine))
     .join('\n\n');
 }
 
+function formatSingleResult(engine: string, data: EngineResultData, isPrimary: boolean): string {
+  return [
+    `// ${isPrimary ? '🟢' : '⚪️'} ${engine} Engine Result`,
+    data.result,
+    `// ${isPrimary ? '========================' : '----------------------------------------'}`,
+  ].join('\n');
+}
+
 export function formatResults(results: any[]): string {
-  return results.map((res) => {
-    if (typeof res === 'object') {
-      const reasonString = Array.isArray(res.reason) && res.reason.length > 0 
-        ? ` Reason: ${JSON.stringify(res.reason)}` 
-        : '';
-      return `${res.okEx}${reasonString}`;
-    }
-    return res;
-  }).join('\n');
+  return results
+    .map((res) => {
+      if (typeof res === 'object') {
+        const reasonString = Array.isArray(res.reason) && res.reason.length > 0 ? ` Reason: ${JSON.stringify(res.reason)}` : '';
+        return `${res.okEx}${reasonString}`;
+      }
+      return res;
+    })
+    .join('\n');
 }
 
 export function createResultsMap(results: Array<{ engine: string; result: string }>): ResultsMap {

--- a/app/utils/resultFormatter.ts
+++ b/app/utils/resultFormatter.ts
@@ -19,7 +19,9 @@ export function formatEngineResults(results: ResultsMap, selectedEngine: EngineT
       if (b[0] === selectedEngine) return 1;
       return ENGINES[a[0] as EngineType].order - ENGINES[b[0] as EngineType].order;
     })
-    .map(([engine, data]) => formatSingleResult(engine, data, engine === selectedEngine))
+    .map(([engine, data]) => {
+      return formatSingleResult(engine, data, engine === selectedEngine);
+    })
     .join('\n\n');
 }
 


### PR DESCRIPTION
fix: https://github.com/casbin/casbin-editor/issues/225

- Created centralized engine configuration in `app/config/engineConfig.ts`