### PR TITLE
fix: resolve duplicate request issue

### DIFF
--- a/app/components/editor/index.tsx
+++ b/app/components/editor/index.tsx
@@ -64,7 +64,6 @@ export const EditorScreen = () => {
   const [open, setOpen] = useState(true);
   const [isContentLoaded, setIsContentLoaded] = useState(false);
   const [showCustomConfig, setShowCustomConfig] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
   const [requestResults, setRequestResults] = useState<ResultsMap>({});
   const skipNextEffectRef = useRef(false);
   const sidePanelChatRef = useRef<{ openDrawer: (message: string) => void } | null>(null);
@@ -72,8 +71,8 @@ export const EditorScreen = () => {
     onChange: setEnforceContextDataPersistent,
     data: enforceContextData,
   });
-  const { versions, engineGithubLinks } = useEngineVersions(isLoading);
-  const { handleEnforcerCall } = useEnforceCall(enforcer, setEcho, setRequestResult, setRequestResults, setIsLoading, t);
+  const { versions, engineGithubLinks } = useEngineVersions();
+  const { handleEnforcerCall, isLoading } = useEnforceCall(enforcer, setEcho, setRequestResult, setRequestResults, t);
   const openDrawerWithMessage = (message: string) => {
     if (sidePanelChatRef.current) {
       sidePanelChatRef.current.openDrawer(message);

--- a/app/components/hooks/useEnforceCall.ts
+++ b/app/components/hooks/useEnforceCall.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { formatResults, createResultsMap, ResultsMap } from '@/app/utils/resultFormatter';
 import { isValidElement } from 'react';
 import { toast } from 'react-hot-toast';
@@ -20,9 +20,10 @@ export function useEnforceCall(
   setEcho: (v: React.ReactNode) => void,
   setRequestResult: (v: string) => void,
   setRequestResults: (v: ResultsMap) => void,
-  setIsLoading: (v: boolean) => void,
   t: (key: string) => string,
 ) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const handleEnforcerCall = useCallback(
     async (params: EnforceCallParams) => {
       setRequestResult('');
@@ -69,8 +70,8 @@ export function useEnforceCall(
 
       setIsLoading(false);
     },
-    [enforcer, setEcho, setRequestResult, setRequestResults, setIsLoading, t],
+    [enforcer, setEcho, setRequestResult, setRequestResults, t],
   );
 
-  return { handleEnforcerCall };
+  return { handleEnforcerCall, isLoading };
 }

--- a/app/components/hooks/useEngineVersions.ts
+++ b/app/components/hooks/useEngineVersions.ts
@@ -8,7 +8,7 @@ export interface EngineVersionsReturn {
   engineGithubLinks: Record<EngineType, string>;
 }
 
-export default function useEngineVersions(isEngineLoading: boolean): EngineVersionsReturn {
+export default function useEngineVersions(): EngineVersionsReturn {
   const [versions, setVersions] = useState<Record<EngineType, VersionInfo>>(() => {
     return Object.fromEntries(
       Object.keys(ENGINES).map((key) => {
@@ -21,8 +21,6 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
 
   useEffect(() => {
     const fetchVersions = async () => {
-      if (isEngineLoading) return;
-
       try {
         const versionEntries = await Promise.all(
           Object.entries(ENGINES).map(async ([type, config]) => {
@@ -44,7 +42,7 @@ export default function useEngineVersions(isEngineLoading: boolean): EngineVersi
     };
 
     fetchVersions();
-  }, [isEngineLoading]);
+  }, []);
 
   const getVersionedLink = (repo: string, version?: string | null) => {
     return version && version !== 'unknown'


### PR DESCRIPTION

## Description:
The previous version acquisition depends on the `isLoading` state, and each `enforce` operation will trigger version re-acquisition, consuming api requests

## Resolve:
Decouple version fetching from the `loading` state of the `enforce` operation.